### PR TITLE
update to xcode 5 lang change

### DIFF
--- a/Example/SwizzlingExample/AppDelegate.swift
+++ b/Example/SwizzlingExample/AppDelegate.swift
@@ -49,7 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     
     func swizzleNSDictionaryMethods() {
-        var dict:NSDictionary = ["SomeObject": kSecValueRef]
+        var dict:NSDictionary = ["SomeObject": "some"]
 
         NSDictionary.swizzleMethodSelector("description", withSelector: "swizzled_Description", forClass: NSDictionary.classForCoder())
         

--- a/Example/SwizzlingExample/MBSwizzler.swift
+++ b/Example/SwizzlingExample/MBSwizzler.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension NSObject {
     
-    class func swizzleMethodSelector(origSelector: CString!, withSelector: CString!, forClass:AnyClass!) -> Bool {
+    class func swizzleMethodSelector(origSelector: String!, withSelector: String!, forClass:AnyClass!) -> Bool {
         
         var originalMethod: Method?
         var swizzledMethod: Method?
@@ -18,14 +18,14 @@ extension NSObject {
         originalMethod = class_getInstanceMethod(forClass, Selector.convertFromStringLiteral(origSelector))
         swizzledMethod = class_getInstanceMethod(forClass, Selector.convertFromStringLiteral(withSelector))
         
-        if (originalMethod && swizzledMethod) {
+        if (originalMethod != nil && swizzledMethod != nil) {
             method_exchangeImplementations(originalMethod!, swizzledMethod!)
             return true
         }
         return false
     }
     
-    class func swizzleStaticMethodSelector(origSelector: CString!, withSelector: CString!, forClass:AnyClass!) -> Bool {
+    class func swizzleStaticMethodSelector(origSelector: String!, withSelector: String!, forClass:AnyClass!) -> Bool {
         
         var originalMethod: Method?
         var swizzledMethod: Method?
@@ -33,7 +33,7 @@ extension NSObject {
         originalMethod = class_getClassMethod(forClass, Selector.convertFromStringLiteral(origSelector))
         swizzledMethod = class_getClassMethod(forClass, Selector.convertFromStringLiteral(withSelector))
         
-        if (originalMethod && swizzledMethod) {
+        if (originalMethod != nil && swizzledMethod != nil) {
             method_exchangeImplementations(originalMethod!, swizzledMethod!)
             return true
         }


### PR DESCRIPTION
although the program runs, I get an ``EXC_BAD_ACCESS` on the swizzled methods on the new Xcode Beta 5  (working on the previously Beta 4)  Digging a bit and adding a println() log statement on the swizzled methods reveals an infinite recursion that is calling the _original_ method still calls the swizzled one.  Possible some lang semantics have changed. 

Would be great if you have an idea or hint. Thanks!
