### PR TITLE
NSString example

### DIFF
--- a/Example/SwizzlingExample.xcodeproj/project.pbxproj
+++ b/Example/SwizzlingExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		48CC680D19A235C20004DFE3 /* Ext.m in Sources */ = {isa = PBXBuildFile; fileRef = 48CC680C19A235C20004DFE3 /* Ext.m */; };
 		B151271319406DB800CB4446 /* MyClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B151271219406DB800CB4446 /* MyClass.swift */; };
 		B1B4F3BB193FAC2900B6B869 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B4F3BA193FAC2900B6B869 /* AppDelegate.swift */; };
 		B1B4F3BD193FAC2900B6B869 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B1B4F3BC193FAC2900B6B869 /* Images.xcassets */; };
@@ -25,6 +26,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		48CC680519A22EB10004DFE3 /* SwizzlingExample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SwizzlingExample-Bridging-Header.h"; sourceTree = "<group>"; };
+		48CC680C19A235C20004DFE3 /* Ext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Ext.m; path = SwizzlingExample/Ext.m; sourceTree = "<group>"; };
+		48CC680E19A235E70004DFE3 /* Ext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Ext.h; path = SwizzlingExample/Ext.h; sourceTree = "<group>"; };
 		B151271219406DB800CB4446 /* MyClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyClass.swift; sourceTree = "<group>"; };
 		B1B4F3B5193FAC2900B6B869 /* SwizzlingExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwizzlingExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1B4F3B9193FAC2900B6B869 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -57,6 +61,8 @@
 		B1B4F3AC193FAC2900B6B869 = {
 			isa = PBXGroup;
 			children = (
+				48CC680C19A235C20004DFE3 /* Ext.m */,
+				48CC680E19A235E70004DFE3 /* Ext.h */,
 				B1B4F3B7193FAC2900B6B869 /* SwizzlingExample */,
 				B1B4F3C5193FAC2900B6B869 /* SwizzlingExampleTests */,
 				B1B4F3B6193FAC2900B6B869 /* Products */,
@@ -80,6 +86,7 @@
 				B151271219406DB800CB4446 /* MyClass.swift */,
 				B1B4F3BC193FAC2900B6B869 /* Images.xcassets */,
 				B1B4F3B8193FAC2900B6B869 /* Supporting Files */,
+				48CC680519A22EB10004DFE3 /* SwizzlingExample-Bridging-Header.h */,
 			);
 			path = SwizzlingExample;
 			sourceTree = "<group>";
@@ -207,6 +214,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B151271319406DB800CB4446 /* MyClass.swift in Sources */,
+				48CC680D19A235C20004DFE3 /* Ext.m in Sources */,
 				B1B4F3BB193FAC2900B6B869 /* AppDelegate.swift in Sources */,
 				B1DC3C0A19408BD70022B938 /* MBSwizzler.swift in Sources */,
 			);
@@ -313,9 +321,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = SwizzlingExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "SwizzlingExample/SwizzlingExample-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
@@ -324,9 +335,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = SwizzlingExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "SwizzlingExample/SwizzlingExample-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/Example/SwizzlingExample/AppDelegate.swift
+++ b/Example/SwizzlingExample/AppDelegate.swift
@@ -10,6 +10,7 @@ import UIKit
 
 extension NSDictionary {
     func swizzled_Description() -> String!{
+        println("in swizzled_description")
         return "\nTest 1. Hooked description \n" + swizzled_Description();
     }
 }
@@ -29,6 +30,22 @@ extension MyClass {
     }
 }
 
+extension NSString {
+    class func swizzled_defaultCStringEncoding() -> UInt {
+        println("\nTest 4. NSString hooked \n")
+        return UInt(9999)
+    }
+    
+    class func foo() {
+        println("\nReal foo \n")
+    }
+    
+    class func swizzled_foo() {
+        println("\nSwizzled foo \n")
+    }
+}
+
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
                             
@@ -41,15 +58,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.window!.backgroundColor = UIColor.whiteColor()
         self.window!.makeKeyAndVisible()
         self.window!.rootViewController = UIViewController(nibName: nil, bundle: nil)
-        swizzleNSDictionaryMethods()
-        swizzleCustomClassMethods()
-        swizzleCustomClassStaticMethods()
+        //swizzleNSDictionaryMethods()
+        //swizzleCustomClassMethods()
+        //swizzleCustomClassStaticMethods()
+        swizzleNSStringClassStaticMethods()
         return true
     }
 
     
     func swizzleNSDictionaryMethods() {
-        var dict:NSDictionary = ["SomeObject": kSecValueRef]
+        var dict:NSDictionary = ["SomeObject": "some"]
 
         NSDictionary.swizzleMethodSelector("description", withSelector: "swizzled_Description", forClass: NSDictionary.classForCoder())
         
@@ -67,6 +85,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func swizzleCustomClassStaticMethods() {
         MyClass.swizzleStaticMethodSelector("testClassMethod", withSelector: "swizzled_testClassMethod", forClass: MyClass.classForCoder())
         println(MyClass.testClassMethod()) //Check
+    }
+    
+    func swizzleNSStringClassStaticMethods() {
+        NSString.swizzleStaticMethodSelector("defaultCStringEncoding", withSelector: "swizzled_defaultCStringEncoding", forClass: NSString.classForCoder())
+        println(NSString.defaultCStringEncoding())
+        
+        NSString.swizzleStaticMethodSelector("foo", withSelector: "swizzled_foo", forClass: NSString.classForCoder())
+        println(NSString.foo())
+        
     }
 
     func applicationWillResignActive(application: UIApplication) {

--- a/Example/SwizzlingExample/AppDelegate.swift
+++ b/Example/SwizzlingExample/AppDelegate.swift
@@ -61,7 +61,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         //swizzleNSDictionaryMethods()
         //swizzleCustomClassMethods()
         //swizzleCustomClassStaticMethods()
-        swizzleNSStringClassStaticMethods()
+        //swizzleNSStringClassStaticMethods()
+        swizzleCustomClassMethodsBis()
         return true
     }
 
@@ -72,6 +73,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NSDictionary.swizzleMethodSelector("description", withSelector: "swizzled_Description", forClass: NSDictionary.classForCoder())
         
         println(dict.description) //Check
+    }
+    
+    func swizzleCustomClassMethodsBis() {
+        var custom: MyClassC = MyClassC(title: "Custom")
+        
+        MyClassC.swizzleMethodSelector("testWithParameter:", withSelector: "swizzled_testWithParameter:", forClass: MyClassC.classForCoder())
+        
+        println(custom.testWithParameter("Param1")) //Check
     }
     
     func swizzleCustomClassMethods() {

--- a/Example/SwizzlingExample/Ext.h
+++ b/Example/SwizzlingExample/Ext.h
@@ -1,0 +1,24 @@
+//
+//  Ext.h
+//  SwizzlingExample
+//
+//  Created by Corinne Krych on 18/08/14.
+//  Copyright (c) 2014 Home. All rights reserved.
+//
+#import <Foundation/Foundation.h>
+#ifndef SwizzlingExample_Ext_h
+#define SwizzlingExample_Ext_h
+
+
+#endif
+
+@interface MyClassC : NSObject
+
+@property NSString* title;
+
+-(instancetype)initWithTitle:(NSString*)myTitle;
+-(NSString*) testWithParameter:(id)AnyObject;
+-(NSString*) testMethod;
++(NSString*) testClassMethod;
++(BOOL)swizzleMethodSelector:(SEL)origSelector withSelector:(SEL)withSelector forClass:(id)forClass;
+@end

--- a/Example/SwizzlingExample/Ext.m
+++ b/Example/SwizzlingExample/Ext.m
@@ -1,0 +1,58 @@
+//
+//  Ext.m
+//  SwizzlingExample
+//
+//  Created by Corinne Krych on 18/08/14.
+//  Copyright (c) 2014 Home. All rights reserved.
+//
+
+
+#import <objc/runtime.h>
+#import "Ext.h"
+
+
+
+
+@implementation MyClassC
+
+@synthesize title;
+
+-(instancetype)initWithTitle:(NSString*)myTitle {
+    self = [super init];
+    if (self) {
+        self.title = myTitle;
+    }
+    return self;
+}
+
+
+-(NSString*) testWithParameter:(id)AnyObject {
+    return @"Method with parameter";
+}
+
+-(NSString*) swizzled_testWithParameter:(id)AnyObject {
+    return @"Swizzled Method with parameter";
+}
+
+-(NSString*) testMethod {
+    return @"testMethod";
+}
+
++(NSString*) testClassMethod {
+    return @"testClassMethod";
+}
+
++(BOOL)swizzleMethodSelector:(SEL)origSelector withSelector:(SEL)withSelector forClass:(id)forClass {
+    SEL originalSelector = origSelector;
+    SEL swizzledSelector = withSelector;
+    
+    Method originalMethod = class_getInstanceMethod(forClass, originalSelector);
+    Method swizzledMethod = class_getInstanceMethod(forClass, swizzledSelector);
+    if (originalMethod != nil && swizzledMethod != nil) {
+        method_exchangeImplementations(originalMethod, swizzledMethod);
+        return YES;
+    }
+    return NO;
+}
+
+@end

--- a/Example/SwizzlingExample/MBSwizzler.swift
+++ b/Example/SwizzlingExample/MBSwizzler.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension NSObject {
     
-    class func swizzleMethodSelector(origSelector: CString!, withSelector: CString!, forClass:AnyClass!) -> Bool {
+    class func swizzleMethodSelector(origSelector: String!, withSelector: String!, forClass:AnyClass!) -> Bool {
         
         var originalMethod: Method?
         var swizzledMethod: Method?
@@ -18,14 +18,14 @@ extension NSObject {
         originalMethod = class_getInstanceMethod(forClass, Selector.convertFromStringLiteral(origSelector))
         swizzledMethod = class_getInstanceMethod(forClass, Selector.convertFromStringLiteral(withSelector))
         
-        if (originalMethod && swizzledMethod) {
+        if (originalMethod != nil && swizzledMethod != nil) {
             method_exchangeImplementations(originalMethod!, swizzledMethod!)
             return true
         }
         return false
     }
     
-    class func swizzleStaticMethodSelector(origSelector: CString!, withSelector: CString!, forClass:AnyClass!) -> Bool {
+    class func swizzleStaticMethodSelector(origSelector: String!, withSelector: String!, forClass:AnyClass!) -> Bool {
         
         var originalMethod: Method?
         var swizzledMethod: Method?
@@ -33,7 +33,7 @@ extension NSObject {
         originalMethod = class_getClassMethod(forClass, Selector.convertFromStringLiteral(origSelector))
         swizzledMethod = class_getClassMethod(forClass, Selector.convertFromStringLiteral(withSelector))
         
-        if (originalMethod && swizzledMethod) {
+        if (originalMethod != nil && swizzledMethod != nil) {
             method_exchangeImplementations(originalMethod!, swizzledMethod!)
             return true
         }

--- a/Example/SwizzlingExample/SwizzlingExample-Bridging-Header.h
+++ b/Example/SwizzlingExample/SwizzlingExample-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+#import "Ext.h"


### PR DESCRIPTION
Same as @cvasilak I noticed with Swift beta5 it looks like extension methods IMPL can not be set. Custom class methods can not be set either.

Even though MyClass inherits from NSObject (which is a pre-requisites for swizzling), testClassMethod is not replaced by swizzled_testClassMethod

However defaultCStringEncoding is replaced by swizzled_defaultCStringEncoding

Those examples used to work on beta4, not sure what's happening in beta5. Broken compatibility with objc?
Help welcome.
